### PR TITLE
Fixed team policy installation

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -62,6 +62,7 @@ class InstallCommand extends Command
 
         // Models...
         copy(__DIR__.'/../../stubs/app/Models/Team.php', app_path('Models/Team.php'));
+        copy(__DIR__.'/../../stubs/app/Policies/TeamPolicy.php', app_path('Policies/TeamPolicy.php'));
         copy(__DIR__.'/../../stubs/resources/views/teams/team-transfer-form.blade.php', resource_path('views/teams/team-transfer-form.blade.php'));
     }
 }


### PR DESCRIPTION
The installation documentation says `TeamPolicy` will be replaced with a version that supports `transferTeam` but the installation command only installs a new `Team model`  and `team-transfer-form` blade.

This change will also install the `TeamPolicy` file