### PR TITLE
[1.x] Validate new owner belongs to team before transferring.

### DIFF
--- a/src/Actions/TransferTeam.php
+++ b/src/Actions/TransferTeam.php
@@ -20,7 +20,7 @@ class TransferTeam
     public function transfer($user, $team, $teamMember)
     {
         $this->authorize($user, $team, $teamMember);
-        
+
         $this->ensureTeamUserExists($team, $teamMember);
 
         $team->transfer($user, $teamMember);
@@ -46,7 +46,7 @@ class TransferTeam
 
     /**
      * Ensure that the new owner is part of the team.
-     * 
+     *
      * @param  mixed  $team
      * @param  mixed  $user
      * @return void
@@ -55,7 +55,7 @@ class TransferTeam
     {
         if (! $team->hasUser($user)) {
             throw ValidationException::withMessages([
-                'You cannot transfer team ownership to users outside of this team.'
+                'You cannot transfer team ownership to users outside of this team.',
             ])->errorBag('transferTeam');
         }
     }

--- a/src/Actions/TransferTeam.php
+++ b/src/Actions/TransferTeam.php
@@ -4,6 +4,7 @@ namespace JoelButcher\JetstreamTeamTransfer\Actions;
 
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
 use JoelButcher\JetstreamTeamTransfer\Events\TeamTransferred;
 
 class TransferTeam
@@ -19,6 +20,8 @@ class TransferTeam
     public function transfer($user, $team, $teamMember)
     {
         $this->authorize($user, $team, $teamMember);
+        
+        $this->ensureTeamUserExists($team, $teamMember);
 
         $team->transfer($user, $teamMember);
 
@@ -38,6 +41,22 @@ class TransferTeam
         if (! Gate::forUser($user)->check('transferTeam', $team) &&
             $user->id !== $teamMember->id) {
             throw new AuthorizationException;
+        }
+    }
+
+    /**
+     * Ensure that the new owner is part of the team.
+     * 
+     * @param  mixed  $team
+     * @param  mixed  $user
+     * @return void
+     */
+    protected function ensureTeamUserExists($team, $user)
+    {
+        if (! $team->hasUser($user)) {
+            throw ValidationException::withMessages([
+                'You cannot transfer team ownership to users outside of this team.'
+            ])->errorBag('transferTeam');
         }
     }
 }

--- a/src/Http/Livewire/TeamTransferForm.php
+++ b/src/Http/Livewire/TeamTransferForm.php
@@ -88,7 +88,7 @@ class TeamTransferForm extends Component
 
         $teamMember = Jetstream::findUserByEmailOrFail($this->transferTeamForm['email']);
 
-        if ($this->team->hasUser($teamMember)) {
+        if (!$this->team->hasUser($teamMember)) {
             $this->dangerBanner('You cannot transfer team ownership to users outside of this team.');
 
             $this->confirmingTransferTeam = false;

--- a/src/Http/Livewire/TeamTransferForm.php
+++ b/src/Http/Livewire/TeamTransferForm.php
@@ -91,7 +91,7 @@ class TeamTransferForm extends Component
         if (!$this->team->hasUser($teamMember)) {
             $this->dangerBanner('You cannot transfer team ownership to a user outside of this team.');
 
-            $this->confirmingTransferTeam = false;
+            $this->confirmingTeamTransfer= false;
 
             return;
         }

--- a/src/Http/Livewire/TeamTransferForm.php
+++ b/src/Http/Livewire/TeamTransferForm.php
@@ -88,7 +88,6 @@ class TeamTransferForm extends Component
 
         $teamMember = Jetstream::findUserByEmailOrFail($this->transferTeamForm['email']);
 
-        if (!$this->team->hasUser($teamMember)) {
         if (! $this->team->hasUser($teamMember)) {
             $this->dangerBanner('You cannot transfer team ownership to a user outside of this team.');
 

--- a/src/Http/Livewire/TeamTransferForm.php
+++ b/src/Http/Livewire/TeamTransferForm.php
@@ -89,7 +89,7 @@ class TeamTransferForm extends Component
         $teamMember = Jetstream::findUserByEmailOrFail($this->transferTeamForm['email']);
 
         if (!$this->team->hasUser($teamMember)) {
-            $this->dangerBanner('You cannot transfer team ownership to users outside of this team.');
+            $this->dangerBanner('You cannot transfer team ownership to a user outside of this team.');
 
             $this->confirmingTransferTeam = false;
 

--- a/src/Http/Livewire/TeamTransferForm.php
+++ b/src/Http/Livewire/TeamTransferForm.php
@@ -85,9 +85,9 @@ class TeamTransferForm extends Component
                 'password' => [__('This password does not match our records.')],
             ]);
         }
-        
+
         $teamMember = Jetstream::findUserByEmailOrFail($this->transferTeamForm['email']);
-        
+
         if ($this->team->hasUser($teamMember)) {
             $this->dangerBanner('You cannot transfer team ownership to users outside of this team.');
 

--- a/src/Http/Livewire/TeamTransferForm.php
+++ b/src/Http/Livewire/TeamTransferForm.php
@@ -89,6 +89,7 @@ class TeamTransferForm extends Component
         $teamMember = Jetstream::findUserByEmailOrFail($this->transferTeamForm['email']);
 
         if (!$this->team->hasUser($teamMember)) {
+        if (! $this->team->hasUser($teamMember)) {
             $this->dangerBanner('You cannot transfer team ownership to a user outside of this team.');
 
             $this->confirmingTeamTransfer= false;


### PR DESCRIPTION
This PR introduces a fix for a possible bug whereby teams could potentially be transferred to users that aren't a part of that team, as pointed out by @iantasker in #4.

A new check is made on the form submit action and a validation step is added to the `TransferTeam` logic.